### PR TITLE
updated ecs cpu and memory config

### DIFF
--- a/global.tf
+++ b/global.tf
@@ -31,6 +31,9 @@ variable "names" {
       "ecs_instance_count"    = 1
       "waf_create"            = "true"
       "whitelist_ips"         = ["0.0.0.0/0"]
+      "ecs_cpu"               = 512
+      "ecs_memory"            = 1024
+
     }
 
     "test" = {
@@ -59,6 +62,8 @@ variable "names" {
       "ecs_instance_count"    = 1
       "waf_create"            = "true"
       "whitelist_ips"         = ["0.0.0.0/0"]
+      "ecs_cpu"               = 512
+      "ecs_memory"            = 1024
     }
 
     "uat" = {
@@ -88,6 +93,8 @@ variable "names" {
       "ecs_instance_count"    = 1
       "waf_create"            = "true"
       "whitelist_ips"         = ["0.0.0.0/0"]
+      "ecs_cpu"               = 512
+      "ecs_memory"            = 1024
     }
 
     "oat" = {
@@ -116,6 +123,8 @@ variable "names" {
       "ecs_instance_count"    = 3
       "waf_create"            = "true"
       "whitelist_ips"         = ["0.0.0.0/0"]
+      "ecs_cpu"               = 1024
+      "ecs_memory"            = 4096
     }
 
     "prod" = {
@@ -144,6 +153,8 @@ variable "names" {
       "ecs_instance_count"    = 3
       "waf_create"            = "true"
       "whitelist_ips"         = ["0.0.0.0/0"]
+      "ecs_cpu"               = 1024
+      "ecs_memory"            = 4096
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,8 @@ module "ecs" {
   whitelist_ips    = var.env == "prod" ? jsondecode(data.aws_secretsmanager_secret_version.terraform_secret_version.secret_string)["whitelist-ips"] : var.names["${var.env}"]["whitelist_ips"]
   domain_name      = jsondecode(data.aws_secretsmanager_secret_version.terraform_secret_version.secret_string)["domain-name"]
   validation_email = jsondecode(data.aws_secretsmanager_secret_version.terraform_secret_version.secret_string)["validation-email"]
+  ecs_cpu          = var.names["${var.env}"]["ecs_cpu"]
+  ecs_memory       = var.names["${var.env}"]["ecs_memory"]
 }
 
 module "ecr" {

--- a/modules/container-service/main.tf
+++ b/modules/container-service/main.tf
@@ -23,8 +23,8 @@ resource "aws_ecs_task_definition" "ecs-task-definition" {
   family                   = "${var.account}-ecs-${var.env}-${var.system}-task-definition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = 1024
-  memory                   = 4096
+  cpu                      = var.ecs_cpu
+  memory                   = var.ecs_memory
   execution_role_arn       = aws_iam_role.iam-ecs-task-role.arn
   task_role_arn            = aws_iam_role.iam-ecs-task-role.arn
   container_definitions = jsonencode([{

--- a/modules/container-service/var.tf
+++ b/modules/container-service/var.tf
@@ -39,6 +39,11 @@ variable "container_name" {
 
 }
 
+variable "ecs_cpu" {
+}
+
+variable "ecs_memory" {
+}
 
 variable "image_url" {
   description = "container image url"


### PR DESCRIPTION
Update to all envs to add a new variable for ECS CPU and Memory specification. Env's dev to uat have been reduced to a lower specification, with oat and prod kept the same for now. This is to reduce cost due to being over provisioned.