### PR TITLE
added blockedips waf rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,11 @@ data "aws_wafv2_ip_set" "ip_set" {
   scope = "REGIONAL"
 }
 
+data "aws_wafv2_ip_set" "ip_set_blockedips" {
+  name  = "gscs-waf-blocked-ips"
+  scope = "REGIONAL"
+}
+
 module "waf" {
   source         = "./modules/waf"
   name           = "${var.names["${var.env}"]["accountidentifiers"]}-waf-${var.env}-${var.names["system"]}-acl-eu-west-2"
@@ -130,4 +135,5 @@ module "waf" {
   enable_logging = true
   log_group      = [data.aws_cloudwatch_log_group.waf_log_group.arn]
   waf_ip_set_arn = data.aws_wafv2_ip_set.ip_set.arn
+  waf_ip_set_blockedips_arn = data.aws_wafv2_ip_set.ip_set_blockedips.arn
 }

--- a/modules/waf/variables.tf
+++ b/modules/waf/variables.tf
@@ -13,12 +13,7 @@ variable "log_group" {
 variable "enable_logging" {
   default = false
 }
-variable "waf_scope" {
-
-}
-variable "alb_arn" {
-
-}
-variable "waf_ip_set_arn" {
-
-}
+variable "waf_scope" {}
+variable "alb_arn" {}
+variable "waf_ip_set_arn" {}
+variable "waf_ip_set_blockedips_arn" {}

--- a/modules/waf/waf.tf
+++ b/modules/waf/waf.tf
@@ -1,8 +1,8 @@
 module "waf" {
   source = "./code"
-  # enabled     = data.external.check_waf_exists.result.result
-  enabled     = var.waf_create
-  name_prefix = var.name
+  # enabled         = data.external.check_waf_exists.result.result
+  enabled           = var.waf_create
+  name_prefix       = var.name
 
   allow_default_action = true
 
@@ -21,11 +21,27 @@ module "waf" {
   log_destination_configs      = var.log_group
   rules = [
 
-    // WAF AWS Managed Rule 
+    // WAF AWS Custom Rule 
+    {
+      name        = "${var.name}-blockedips",
+      priority    = 0
+      action      = "block"
+        
+      ip_set_reference_statement = {
+        arn = var.waf_ip_set_blockedips_arn
+       }
 
+      visibility_config = {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${var.name}-blockedips-metric"
+        sampled_requests_enabled   = true
+      }
+    },
+
+    // WAF AWS Managed Rule 
     {
       name            = "${var.name}-commonruleset"
-      priority        = 0
+      priority        = 1
       override_action = "none"
 
       managed_rule_group_statement = {
@@ -174,9 +190,10 @@ module "waf" {
         sampled_requests_enabled   = false
       }
     },
+
     {
       name            = "${var.name}-knownbadnnputsruleset",
-      priority        = 1
+      priority        = 2
       override_action = "none"
 
       managed_rule_group_statement = {
@@ -205,11 +222,11 @@ module "waf" {
         metric_name                = "${var.name}-knownbadnnputsruleset-metric"
         sampled_requests_enabled   = true
       }
-
     },
+
     {
       name            = "${var.name}-ipreputationlist",
-      priority        = 2
+      priority        = 3
       override_action = "none"
 
       managed_rule_group_statement = {
@@ -238,11 +255,12 @@ module "waf" {
         metric_name                = "${var.name}-ipreputationlist-metric"
         sampled_requests_enabled   = true
       }
-
     },
+
+    // WAF AWS Custom Rule     
     {
       name     = "${var.name}-httpfloodprotection",
-      priority = 3
+      priority = 4
       action   = "count"
 
       rate_based_statement = {
@@ -257,14 +275,13 @@ module "waf" {
         }
       }
 
-
       visibility_config = {
         cloudwatch_metrics_enabled = true
         metric_name                = "${var.name}-httpfloodprotection-metric"
         sampled_requests_enabled   = true
       }
-
     },
+
     # {
     #   name            = "${var.name}-botcontrolruleset",
     #   priority        = 4


### PR DESCRIPTION
Adding a new rule to the FRF aws WAF ACL to allow us to block IPs, using a global IP set. New IP sets can be created and imported into the terraform to allow extra granularity for each system if needed.