### PR TITLE
added new rds scheduler tag for oat

### DIFF
--- a/modules/auroradb/db.tf
+++ b/modules/auroradb/db.tf
@@ -140,7 +140,7 @@ resource "aws_rds_cluster" "rds_cluster" {
       System           = var.app
       aws-backup-daily = true
     },
-    var.add_scheduler_tag ? { "instance-scheduler" = "rds-frf" } : {},
+    var.add_scheduler_tag ? { "instance-scheduler" = var.env == "oat" ? "rds-frf-oat" : "rds-frf" } : {},
     var.env == "prod" ? { "aws-backup-daily" = "true" } : {},
     var.env == "prod" ? { "aws-backup-weekly" = "true" } : {},
   )


### PR DESCRIPTION
This has been added for oat as the BCDR restore has caused our daily backups to fail. Due to a quirk in terraform we initially had to have the cluster come on at 02:00 as that's when the backups would need to run, despite our own backup policy running at 23:00. Due to the BCDR the RDS cluster was restored which has negated this and we now need oat to come on at a our default time, out of hours, to make sure the backup completes successfully.